### PR TITLE
various tcpgecko installer changes

### DIFF
--- a/installer/Makefile
+++ b/installer/Makefile
@@ -1,63 +1,63 @@
+root := .
+project := $(root)/src
+build := $(root)/bin
+libs := $(root)/../../libwiiu/bin
+www := $(root)/../../www
+framework := $(root)/../../framework
+AS=powerpc-eabi-as
 CC=powerpc-eabi-gcc
 CFLAGS=-nostdinc -fno-builtin -c
-LD=powerpc-eabi-ld
-LDFLAGS=-Ttext 1800000 --oformat binary
-project	:=	src
-root:=.
-build	:=	 $(root)/bin
-libs := $(root)/../../libwiiu/bin
-www :=$(root)/../../www
-framework:=$(root)/../../framework
-all: setup main532 main500 main410 main400 main310 main300 main210 main200
+LDFLAGS=-T $(project)/link.ld -nostartfiles -nostdlib -s
+all: clean setup main532 main500 main410 main400 main310 main300 main210 main200
 setup:
 	mkdir -p $(root)/bin/
 main532:
+	$(AS) $(project)/asm.s -o $(root)/asm.o
 	$(CC) $(CFLAGS) -DVER=532 $(project)/*.c
 	#-Wa,-a,-ad
-	cp -r $(root)/*.o $(build)
-	rm $(root)/*.o
-	$(LD) $(LDFLAGS) -o $(build)/code532.bin $(build)/loader.o `find $(build) -name "*.o" ! -name "loader.o"`
+	mv -f $(root)/*.o $(build)
+	$(CC) $(LDFLAGS) -o $(build)/code532.bin $(libs)/532/draw.o $(build)/*.o
 main500:
+	$(AS) $(project)/asm.s -o $(root)/asm.o
 	$(CC) $(CFLAGS) -DVER=500 $(project)/*.c
 	#-Wa,-a,-ad
-	cp -r $(root)/*.o $(build)
-	rm $(root)/*.o
-	$(LD) $(LDFLAGS) -o $(build)/code500.bin $(build)/loader.o `find $(build) -name "*.o" ! -name "loader.o"`
+	mv -f $(root)/*.o $(build)
+	$(CC) $(LDFLAGS) -o $(build)/code500.bin $(libs)/500/draw.o $(build)/*.o
 main410:
+	$(AS) $(project)/asm.s -o $(root)/asm.o
 	$(CC) $(CFLAGS) -DVER=410 $(project)/*.c
 	#-Wa,-a,-ad
-	cp -r $(root)/*.o $(build)
-	rm $(root)/*.o
-	$(LD) $(LDFLAGS) -o $(build)/code410.bin $(build)/loader.o `find $(build) -name "*.o" ! -name "loader.o"`
+	mv -f $(root)/*.o $(build)
+	$(CC) $(LDFLAGS) -o $(build)/code410.bin $(libs)/410/draw.o $(build)/*.o
 main400:
+	$(AS) $(project)/asm.s -o $(root)/asm.o
 	$(CC) $(CFLAGS) -DVER=400 $(project)/*.c
 	#-Wa,-a,-ad
-	cp -r $(root)/*.o $(build)
-	rm $(root)/*.o
-	$(LD) $(LDFLAGS) -o $(build)/code400.bin $(build)/loader.o `find $(build) -name "*.o" ! -name "loader.o"`
+	mv -f $(root)/*.o $(build)
+	$(CC) $(LDFLAGS) -o $(build)/code400.bin $(libs)/400/draw.o $(build)/*.o
 main310:
+	$(AS) $(project)/asm.s -o $(root)/asm.o
 	$(CC) $(CFLAGS) -DVER=310 $(project)/*.c
 	#-Wa,-a,-ad
-	cp -r $(root)/*.o $(build)
-	rm $(root)/*.o
-	$(LD) $(LDFLAGS) -o $(build)/code310.bin $(build)/loader.o `find $(build) -name "*.o" ! -name "loader.o"`
+	mv -f $(root)/*.o $(build)
+	$(CC) $(LDFLAGS) -o $(build)/code310.bin $(libs)/310/draw.o $(build)/*.o
 main300:
+	$(AS) $(project)/asm.s -o $(root)/asm.o
 	$(CC) $(CFLAGS) -DVER=300 $(project)/*.c
 	#-Wa,-a,-ad
-	cp -r $(root)/*.o $(build)
-	rm $(root)/*.o
-	$(LD) $(LDFLAGS) -o $(build)/code300.bin $(build)/loader.o `find $(build) -name "*.o" ! -name "loader.o"`
+	mv -f $(root)/*.o $(build)
+	$(CC) $(LDFLAGS) -o $(build)/code300.bin $(libs)/300/draw.o $(build)/*.o
 main210:
+	$(AS) $(project)/asm.s -o $(root)/asm.o
 	$(CC) $(CFLAGS) -DVER=210 $(project)/*.c
 	#-Wa,-a,-ad
-	cp -r $(root)/*.o $(build)
-	rm $(root)/*.o
-	$(LD) $(LDFLAGS) -o $(build)/code210.bin $(build)/loader.o `find $(build) -name "*.o" ! -name "loader.o"`
+	mv -f $(root)/*.o $(build)
+	$(CC) $(LDFLAGS) -o $(build)/code210.bin $(libs)/210/draw.o $(build)/*.o
 main200:
+	$(AS) $(project)/asm.s -o $(root)/asm.o
 	$(CC) $(CFLAGS) -DVER=200 $(project)/*.c
 	#-Wa,-a,-ad
-	cp -r $(root)/*.o $(build)
-	rm $(root)/*.o
-	$(LD) $(LDFLAGS) -o $(build)/code200.bin $(build)/loader.o `find $(build) -name "*.o" ! -name "loader.o"`
+	mv -f $(root)/*.o $(build)
+	$(CC) $(LDFLAGS) -o $(build)/code200.bin $(libs)/200/draw.o $(build)/*.o
 clean:
-	rm -r $(build)/*
+	rm -f -r $(build)/*

--- a/installer/src/asm.s
+++ b/installer/src/asm.s
@@ -1,0 +1,11 @@
+
+.section .asmstart
+
+.extern _main
+.globl _start
+_start:
+	# Load a good stack
+	lis 1,0x1AB5
+	ori 1,1,0xD138
+	# Go!
+	b _main

--- a/installer/src/link.ld
+++ b/installer/src/link.ld
@@ -1,0 +1,14 @@
+OUTPUT_ARCH(powerpc:common)
+OUTPUT_FORMAT("binary")
+ENTRY(_start)
+
+SECTIONS {
+	. = 0x01800000;
+
+	.text : { *(.asmstart) *(.text) }
+	.rodata : { *(.rodata .rodata.*) }
+
+	/DISCARD/ : {
+		*(*);
+	}
+}

--- a/installer/src/loader.c
+++ b/installer/src/loader.c
@@ -1,116 +1,106 @@
 #include "loader.h"
+
+#define RW_MEM_MAP 0xA0000000
 #if VER == 200
 	#include "codehandler310.h" //TODO
-	#define INSTALL_ADDR 0xBD1D3000
-	#define PATCH_ADDR	 0xBD01894C
-	#define FLUSH_ADDR	 PATCH_ADDR - 0x0C
-	#define BRANCH_ADDR  INSTALL_ADDR - 0xBC000000
+	#define INSTALL_ADDR  0x011D3000
+	#define MAIN_JMP_ADDR 0x0101894C
 #elif VER == 210
 	#include "codehandler310.h" //TODO
-	#define INSTALL_ADDR 0xBD1D3000
-	#define PATCH_ADDR	 0xBD01894C
-	#define FLUSH_ADDR	 PATCH_ADDR - 0x0C
-	#define BRANCH_ADDR  INSTALL_ADDR - 0xBC000000
+	#define INSTALL_ADDR  0x011D3000
+	#define MAIN_JMP_ADDR 0x0101894C
 #elif VER == 300
 	#include "codehandler310.h" //TODO ???
-	#define INSTALL_ADDR 0xBD1D3000
-	#define PATCH_ADDR	 0xBD01894C
-	#define FLUSH_ADDR	 PATCH_ADDR - 0x0C
-	#define BRANCH_ADDR  INSTALL_ADDR - 0xBC000000
+	#define INSTALL_ADDR  0x011D3000
+	#define MAIN_JMP_ADDR 0x0101894C
 #elif VER == 310
 	#include "codehandler310.h"
-	#define INSTALL_ADDR 0xBD1D3000
-	#define PATCH_ADDR	 0xBD01894C
-	#define FLUSH_ADDR	 PATCH_ADDR - 0x0C
-	#define BRANCH_ADDR  INSTALL_ADDR - 0xBC000000
+	#define INSTALL_ADDR  0x011D3000
+	#define MAIN_JMP_ADDR 0x0101894C
 #elif VER == 400
 	#include "codehandler410.h" //TODO
-	#define INSTALL_ADDR 0xA11DD000
-	#define PATCH_ADDR	 0xA101C55C
-	#define FLUSH_ADDR	 PATCH_ADDR - 0x1C
-	#define BRANCH_ADDR  INSTALL_ADDR - 0xA0000000
+	#define INSTALL_ADDR  0x011DD000
+	#define MAIN_JMP_ADDR 0x0101C55C
 #elif VER == 410
 	#include "codehandler410.h"
-	#define INSTALL_ADDR 0xA11DD000
-	#define PATCH_ADDR	 0xA101C55C
-	#define FLUSH_ADDR	 PATCH_ADDR - 0x1C
-	#define BRANCH_ADDR  INSTALL_ADDR - 0xA0000000
+	#define INSTALL_ADDR  0x011DD000
+	#define MAIN_JMP_ADDR 0x0101C55C
 #elif VER == 500
 	#include "codehandler500.h"
-	#define INSTALL_ADDR 0xA11DD000
-	#define PATCH_ADDR	 0xA101C55C
-	#define FLUSH_ADDR	 PATCH_ADDR - 0x1C
-	#define BRANCH_ADDR  INSTALL_ADDR - 0xA0000000
+	#define INSTALL_ADDR  0x011DD000
+	#define MAIN_JMP_ADDR 0x0101C55C
 #elif VER == 532
 	#include "codehandler532.h"
-	#define INSTALL_ADDR 0xA11DD000
-	#define PATCH_ADDR	 0xA101C55C
-	#define FLUSH_ADDR	 PATCH_ADDR - 0x1C
-	#define BRANCH_ADDR  INSTALL_ADDR - 0xA0000000
+	#define INSTALL_ADDR  0x011DD000
+	#define MAIN_JMP_ADDR 0x0101C55C
 #elif VER == 550
 	#include "codehandler550.h"
-	#define INSTALL_ADDR 0xA11DD000
-	#define PATCH_ADDR	 0xA101C56C
-	#define FLUSH_ADDR	 PATCH_ADDR - 0x1C
-	#define BRANCH_ADDR  INSTALL_ADDR - 0xA0000000
+	#define INSTALL_ADDR  0x011DD000
+	#define MAIN_JMP_ADDR 0x0101C56C
 #endif
 
 #define assert(x) \
-    do { \
-        if (!(x)) \
-            OSFatal("Assertion failed " #x ".\n"); \
-    } while (0)
+	do { \
+		if (!(x)) \
+			OSFatal("Assertion failed " #x ".\n"); \
+	} while (0)
 		
 #define ALIGN_BACKWARD(x,align) \
 	((typeof(x))(((unsigned int)(x)) & (~(align-1))))
 
 int doBL( unsigned int dst, unsigned int src );
+void doOSScreenInit(unsigned int coreinit_handle);
+inline void doOSScreenClear();
+void doOSScreenPrintPos(char *buf, int pos);
+void doVPADWait();
 
-void _start()
+void _main()
 {
-    /* Load a good stack */
-    asm(
-        "lis %r1, 0x1ab5 ;"
-        "ori %r1, %r1, 0xd138 ;"
-    );
-
-    /* Get a handle to coreinit.rpl. */
-    unsigned int coreinit_handle;
-    OSDynLoad_Acquire("coreinit.rpl", &coreinit_handle);
+	/* Get a handle to coreinit.rpl. */
+	unsigned int coreinit_handle;
+	OSDynLoad_Acquire("coreinit.rpl", &coreinit_handle);
 
 	/* Get for later socket patch */
-    unsigned int nsysnet_handle;
-    OSDynLoad_Acquire("nsysnet.rpl", &nsysnet_handle);
+	unsigned int nsysnet_handle;
+	OSDynLoad_Acquire("nsysnet.rpl", &nsysnet_handle);
 
-    /* Load a few useful symbols. */
-	void (*memcpy)(void *dst, const void *src, int bytes);
+	/* Get for IP address print */
+	unsigned int nn_ac_handle;
+	OSDynLoad_Acquire("nn_ac.rpl", &nn_ac_handle);
+
+	/* Load a few useful symbols. */
+	void*(*OSEffectiveToPhysical)(const void *);
 	void*(*OSAllocFromSystem)(uint32_t size, int align);
-	void (*memset)(void *dst, char val, int bytes);
-    void (*_Exit)(void) __attribute__ ((noreturn));
-	void (*ICInvalidateRange)(const void *, int);
-    void*(*OSEffectiveToPhysical)(const void *);
-    void (*DCFlushRange)(const void *, int);
 	void (*OSFreeToSystem)(void *ptr);
+	void (*DCFlushRange)(const void *, int);
+	void (*ICInvalidateRange)(const void *, int);
+	void (*_Exit)(void) __attribute__ ((noreturn));
 
-    OSDynLoad_FindExport(coreinit_handle, 0, "OSEffectiveToPhysical", &OSEffectiveToPhysical);
+	OSDynLoad_FindExport(coreinit_handle, 0, "OSEffectiveToPhysical", &OSEffectiveToPhysical);
 	OSDynLoad_FindExport(coreinit_handle, 0, "OSAllocFromSystem", &OSAllocFromSystem);
-	OSDynLoad_FindExport(coreinit_handle, 0, "ICInvalidateRange", &ICInvalidateRange);
 	OSDynLoad_FindExport(coreinit_handle, 0, "OSFreeToSystem", &OSFreeToSystem);
-    OSDynLoad_FindExport(coreinit_handle, 0, "DCFlushRange", &DCFlushRange);
-	OSDynLoad_FindExport(coreinit_handle, 0, "memcpy", &memcpy);
-	OSDynLoad_FindExport(coreinit_handle, 0, "memset", &memset);
-    OSDynLoad_FindExport(coreinit_handle, 0, "_Exit", &_Exit);
+	OSDynLoad_FindExport(coreinit_handle, 0, "DCFlushRange", &DCFlushRange);
+	OSDynLoad_FindExport(coreinit_handle, 0, "ICInvalidateRange", &ICInvalidateRange);
+	OSDynLoad_FindExport(coreinit_handle, 0, "_Exit", &_Exit);
 
 	assert(OSEffectiveToPhysical);
 	assert(OSAllocFromSystem);
-	assert(ICInvalidateRange);
 	assert(OSFreeToSystem);
-    assert(DCFlushRange);
-    assert(memcpy);
-    assert(memset);
-    assert(_Exit);
+	assert(DCFlushRange);
+	assert(ICInvalidateRange);
+	assert(_Exit);
 
-	//IM functions
+	/* Socket functions */
+	unsigned int *socket_lib_finish;
+	OSDynLoad_FindExport(nsysnet_handle, 0, "socket_lib_finish", &socket_lib_finish);
+	assert(socket_lib_finish);
+
+	/* AC functions */
+	int(*ACGetAssignedAddress)(unsigned int *addr);
+	OSDynLoad_FindExport(nn_ac_handle, 0, "ACGetAssignedAddress", &ACGetAssignedAddress);
+	assert(ACGetAssignedAddress);
+
+	/* IM functions */
 	int(*IM_SetDeviceState)(int fd, void *mem, int state, int a, int b);
 	int(*IM_Close)(int fd);
 	int(*IM_Open)();
@@ -123,61 +113,82 @@ void _start()
 	assert(IM_Close);
 	assert(IM_Open);
 
-	//Restart system to get lib access
+	/* Restart system to get lib access */
 	int fd = IM_Open();
 	void *mem = OSAllocFromSystem(0x100, 64);
 	memset(mem, 0, 0x100);
-	//set restart flag to force quit browser
+
+	/* set restart flag to force quit browser */
 	IM_SetDeviceState(fd, mem, 3, 0, 0); 
 	IM_Close(fd);
 	OSFreeToSystem(mem);
-	//wait a bit for browser end
+
+	/* wait a bit for browser end */
 	unsigned int t1 = 0x1FFFFFFF;
 	while(t1--) ;
 
-    /* Make sure the kernel exploit has been run */
-#if (VER < 410)
-    if (OSEffectiveToPhysical((void *)0xA0000000) != (void *)0x30000000)
-#else
-	if (OSEffectiveToPhysical((void *)0xA0000000) != (void *)0x31000000)
-#endif
+	doOSScreenInit(coreinit_handle);
+	doOSScreenClear();
+	doOSScreenPrintPos("TCPGecko Installer", 0);
+
+	/* Make sure the kernel exploit has been run */
+	if (OSEffectiveToPhysical((void *)0xA0000000) == (void *)0)
 	{
-        OSFatal("You must run ksploit before installing PyGecko.");
-    }
+		doOSScreenPrintPos("You must execute the kernel exploit before installing TCPGecko.", 1);
+		doOSScreenPrintPos("Returning to the home menu...",2);
+		t1 = 0x3FFFFFFF;
+		while(t1--) ;
+		doOSScreenClear();
+		_Exit();
+	}
 	else
 	{
-		/* Get the socket function to patch */
-		unsigned int *topatch;
-		OSDynLoad_FindExport(nsysnet_handle, 0, "socket_lib_finish", &topatch);
-#if (VER < 410)
-		topatch = (unsigned int*)((unsigned int)topatch + 0xBC000000);
-#else
-		topatch = (unsigned int*)((unsigned int)topatch + 0xA0000000);
-#endif
+		doOSScreenPrintPos("Trying to install TCPGecko...", 1);
 
-        /* Install codehandler */
-		memcpy((void*)INSTALL_ADDR, codehandler_text_bin, codehandler_text_bin_len);
-		DCFlushRange((void*)INSTALL_ADDR, codehandler_text_bin_len);
-		ICInvalidateRange((void*)INSTALL_ADDR, codehandler_text_bin_len);
+		/* Our main writable area */
+		unsigned int physWriteLoc = (unsigned int)OSEffectiveToPhysical((void*)RW_MEM_MAP);
+
+		/* Install codehandler */
+		unsigned int phys_codehandler_loc = (unsigned int)OSEffectiveToPhysical((void*)INSTALL_ADDR);
+		void *codehandler_loc = (unsigned int*)(RW_MEM_MAP + (phys_codehandler_loc - physWriteLoc));
+
+		memcpy(codehandler_loc, codehandler_text_bin, codehandler_text_bin_len);
+		DCFlushRange(codehandler_loc, codehandler_text_bin_len);
+		ICInvalidateRange(codehandler_loc, codehandler_text_bin_len);
 
 		/* Patch coreinit jump */
-		*((uint32_t *)PATCH_ADDR) = doBL(BRANCH_ADDR, PATCH_ADDR - 0xA0000000);
-		DCFlushRange((void*)FLUSH_ADDR, 0x20);
-		ICInvalidateRange((void*)FLUSH_ADDR, 0x20);
+		unsigned int phys_main_jmp_loc = (unsigned int)OSEffectiveToPhysical((void*)MAIN_JMP_ADDR);
+		unsigned int *main_jmp_loc = (unsigned int*)(RW_MEM_MAP + (phys_main_jmp_loc - physWriteLoc));
+
+		*main_jmp_loc = doBL(INSTALL_ADDR, MAIN_JMP_ADDR);
+		DCFlushRange(ALIGN_BACKWARD(main_jmp_loc, 32), 0x20);
+		ICInvalidateRange(ALIGN_BACKWARD(main_jmp_loc, 32), 0x20);
 
 		/* Patch Socket Function */
-		topatch[0] = 0x38600000;
-		topatch[1] = 0x4E800020;
-		unsigned int *faddr = ALIGN_BACKWARD(topatch, 32);
-		DCFlushRange(faddr, 0x40);
-		ICInvalidateRange(faddr, 0x40);
+		unsigned int phys_socket_loc = (unsigned int)OSEffectiveToPhysical(socket_lib_finish);
+		unsigned int *socket_loc = (unsigned int*)(RW_MEM_MAP + (phys_socket_loc - physWriteLoc));
 
-        /* The fix for Splatoon and such */
+		socket_loc[0] = 0x38600000;
+		socket_loc[1] = 0x4E800020;
+		DCFlushRange(ALIGN_BACKWARD(socket_loc, 32), 0x40);
+		ICInvalidateRange(ALIGN_BACKWARD(socket_loc, 32), 0x40);
+
+		/* The fix for Splatoon and such */
 		kern_write((void*)(KERN_ADDRESS_TBL + (0x12 * 4)), 0x00000000);
-		kern_write((void*)(KERN_ADDRESS_TBL + (0x13 * 4)), 0x14000000);     
-	}
+		kern_write((void*)(KERN_ADDRESS_TBL + (0x13 * 4)), 0x14000000);
 
-    _Exit();
+		/* All good! */
+		unsigned int addr;
+		ACGetAssignedAddress(&addr);
+		char buf[64];
+		__os_snprintf(buf,64,"Success! Your Gecko IP is %i.%i.%i.%i.", (addr>>24)&0xFF,(addr>>16)&0xFF,(addr>>8)&0xFF,addr&0xFF);
+		doOSScreenPrintPos(buf, 2);
+
+		doOSScreenPrintPos("Press any button to return to the home menu.", 3);
+		doVPADWait();
+	}
+	doOSScreenClear();
+	_Exit();
 }
 
 int doBL( unsigned int dst, unsigned int src )
@@ -186,6 +197,16 @@ int doBL( unsigned int dst, unsigned int src )
 	newval &= 0x03FFFFFC;
 	newval |= 0x48000001;
 	return newval;
+}
+
+
+/* for internal and gcc usage */
+void* memset(void* dst, const uint8_t val, uint32_t size)
+{
+	uint32_t i;
+	for (i = 0; i < size; i++)
+		((uint8_t*) dst)[i] = val;
+	return dst;
 }
 
 void* memcpy(void* dst, const void* src, uint32_t size)
@@ -217,4 +238,76 @@ void kern_write(void *addr, uint32_t value)
 		:	"memory", "ctr", "lr", "0", "3", "4", "5", "6", "7", "8", "9", "10",
 			"11", "12"
 		);
+}
+
+/* OSScreen helper functions */
+void doOSScreenInit(unsigned int coreinit_handle)
+{
+	/* OSScreen functions */
+	void(*OSScreenInit)();
+	unsigned int(*OSScreenGetBufferSizeEx)(unsigned int bufferNum);
+	unsigned int(*OSScreenSetBufferEx)(unsigned int bufferNum, void * addr);
+
+	OSDynLoad_FindExport(coreinit_handle, 0, "OSScreenInit", &OSScreenInit);
+	OSDynLoad_FindExport(coreinit_handle, 0, "OSScreenGetBufferSizeEx", &OSScreenGetBufferSizeEx);
+	OSDynLoad_FindExport(coreinit_handle, 0, "OSScreenSetBufferEx", &OSScreenSetBufferEx);
+
+	assert(OSScreenInit);
+	assert(OSScreenGetBufferSizeEx);
+	assert(OSScreenSetBufferEx);
+
+	/* Call the Screen initilzation function */
+	OSScreenInit();
+
+	/* Grab the buffer size for each screen (TV and gamepad) */
+	int buf0_size = OSScreenGetBufferSizeEx(0);
+	int buf1_size = OSScreenGetBufferSizeEx(1);
+
+	/* Set the buffer area */
+	OSScreenSetBufferEx(0, (void *)0xF4000000);
+	OSScreenSetBufferEx(1, (void *)0xF4000000 + buf0_size);
+}
+
+inline void doOSScreenClear()
+{
+	/* Clear both framebuffers */
+	int ii;
+	for (ii = 0; ii < 2; ii++)
+	{
+		fillScreen(0,0,0,0);
+		flipBuffers();
+	}
+}
+
+void doOSScreenPrintPos(char *buf, int pos)
+{
+	int i;
+	for(i=0;i<2;i++)
+	{
+		drawString(0,pos,buf);
+		flipBuffers();
+	}
+}
+
+void doVPADWait()
+{
+	unsigned int vpad_handle;
+	OSDynLoad_Acquire("vpad.rpl", &vpad_handle);
+
+	/* VPAD functions */
+	int(*VPADRead)(int controller, VPADData *buffer, unsigned int num, int *error);
+	OSDynLoad_FindExport(vpad_handle, 0, "VPADRead", &VPADRead);
+	assert(VPADRead);
+
+	int error;
+	VPADData vpad_data;
+
+	/* Read initial vpad status */
+	VPADRead(0, &vpad_data, 1, &error);
+	while(1)
+	{
+		VPADRead(0, &vpad_data, 1, &error);
+		if(vpad_data.btn_hold)
+			break;
+	}
 }

--- a/installer/src/loader.h
+++ b/installer/src/loader.h
@@ -2,8 +2,10 @@
 #define LOADER_H
 
 #include "../../../libwiiu/src/coreinit.h"
+#include "../../../libwiiu/src/draw.h"
 #include "../../../libwiiu/src/socket.h"
 #include "../../../libwiiu/src/types.h"
+#include "../../../libwiiu/src/vpad.h"
 
 /* Kernel address table */
 #if VER == 200
@@ -28,11 +30,9 @@
 #error "Unsupported Wii U software version"
 #endif
 
-void _start();
-
-void _entryPoint();
-
+void _main();
 void kern_write(void *addr, uint32_t value);
+void* memset(void* dst, const uint8_t val, uint32_t size);
 void* memcpy(void* dst, const void* src, uint32_t size);
 
 #endif /* LOADER_H */


### PR DESCRIPTION
here is a list:
-after the installation the installer will print out the current gecko ip to use in the pc applications for convenience purposes
-instead of crashing when no kernel exploit is present the installer will just inform the user about it and return to the home menu
-the installer will now build the installation area on the fly to properly work with several kernel exploit memory mappings
-edited the build process of tcpgecko to avoid issues with function positions
